### PR TITLE
Socket.io: do not fill the notifications array buffer when socket.io

### DIFF
--- a/src/client/ocpp/ChargingStationClientFactory.ts
+++ b/src/client/ocpp/ChargingStationClientFactory.ts
@@ -23,8 +23,8 @@ export default class ChargingStationClientFactory {
         // JSON
         case OCPPProtocol.JSON:
           // Get the client from Json Server
-          if (global.centralSystemJson) {
-            chargingClient = global.centralSystemJson.getChargingStationClient(tenantID, chargingStation.id);
+          if (global.centralSystemJsonServer) {
+            chargingClient = global.centralSystemJsonServer.getChargingStationClient(tenantID, chargingStation.id);
           }
           // Not Found
           if (!chargingClient) {

--- a/src/server/ocpp/json/JsonCentralSystemServer.ts
+++ b/src/server/ocpp/json/JsonCentralSystemServer.ts
@@ -31,7 +31,7 @@ export default class JsonCentralSystemServer extends CentralSystemServer {
 
   public start() {
     // Keep it global
-    global.centralSystemJson = this;
+    global.centralSystemJsonServer = this;
     // Make server to listen
     this.startListening();
   }

--- a/src/server/ocpp/json/JsonRestWSConnection.ts
+++ b/src/server/ocpp/json/JsonRestWSConnection.ts
@@ -75,7 +75,7 @@ export default class JsonRestWSConnection extends WSConnection {
       });
     }
     // Get the client from JSON Server
-    const chargingStationClient = global.centralSystemJson.getChargingStationClient(this.getTenantID(), chargingStation.id);
+    const chargingStationClient = global.centralSystemJsonServer.getChargingStationClient(this.getTenantID(), chargingStation.id);
     if (!chargingStationClient) {
       throw new BackendError({
         source: this.getChargingStationID(),

--- a/src/server/ocpp/json/services/JsonChargingStationService.ts
+++ b/src/server/ocpp/json/services/JsonChargingStationService.ts
@@ -13,7 +13,7 @@ export default class JsonChargingStationService {
   constructor(chargingStationConfig: ChargingStationConfiguration) {
     this.chargingStationConfig = chargingStationConfig;
     // Get the OCPP service
-    this.chargingStationService = global.centralSystemJson.getChargingStationService(OCPPVersion.VERSION_16);
+    this.chargingStationService = global.centralSystemJsonServer.getChargingStationService(OCPPVersion.VERSION_16);
   }
 
   public async handleBootNotification(headers, payload) {

--- a/src/server/ocpp/soap/SoapCentralSystemServer.ts
+++ b/src/server/ocpp/soap/SoapCentralSystemServer.ts
@@ -62,7 +62,7 @@ export default class SoapCentralSystemServer extends CentralSystemServer {
    */
   start() {
     // Make it global for SOAP Services
-    global.centralSystemSoap = this;
+    global.centralSystemSoapServer = this;
 
     expressTools.startServer(this.centralSystemConfig, this.httpServer, 'OCPP Soap', MODULE_NAME);
 

--- a/src/server/ocpp/soap/services/SoapCentralSystemService12.ts
+++ b/src/server/ocpp/soap/services/SoapCentralSystemService12.ts
@@ -18,7 +18,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleAuthorize(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleAuthorize(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, {
             'result': result
@@ -51,7 +51,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleStartTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleStartTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, {
             'result': result
@@ -85,7 +85,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleStopTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleStopTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, {
             'result': result
@@ -116,11 +116,11 @@ export default { /* Services */
         Utils.normalizeAndCheckSOAPParams(headers, req).then(async () => {
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleHeartbeat(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleHeartbeat(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, {
             'result': result
@@ -148,7 +148,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleMeterValues(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleMeterValues(headers, args);
           // Return the result async
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, {
             'result': result
@@ -174,11 +174,11 @@ export default { /* Services */
           headers.ocppProtocol = OCPPProtocol.SOAP;
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleBootNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleBootNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, {
             'result': result
@@ -210,7 +210,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, {
             'result': result
@@ -235,7 +235,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleFirmwareStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleFirmwareStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, {
             'result': result
@@ -259,7 +259,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_12).handleDiagnosticsStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_12).handleDiagnosticsStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, {
             'result': result

--- a/src/server/ocpp/soap/services/SoapCentralSystemService15.ts
+++ b/src/server/ocpp/soap/services/SoapCentralSystemService15.ts
@@ -18,7 +18,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleAuthorize(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleAuthorize(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, {
             'result': result
@@ -51,7 +51,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleStartTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleStartTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, {
             'result': result
@@ -85,7 +85,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleStopTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleStopTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, {
             'result': result
@@ -116,11 +116,11 @@ export default { /* Services */
         Utils.normalizeAndCheckSOAPParams(headers, req).then(async () => {
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleHeartbeat(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleHeartbeat(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, {
             'result': result
@@ -148,7 +148,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleMeterValues(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleMeterValues(headers, args);
           // Return the result async
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, {
             'result': result
@@ -174,11 +174,11 @@ export default { /* Services */
           headers.ocppProtocol = OCPPProtocol.SOAP;
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleBootNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleBootNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, {
             'result': result
@@ -210,7 +210,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, {
             'result': result
@@ -235,7 +235,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleFirmwareStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleFirmwareStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, {
             'result': result
@@ -259,7 +259,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleDiagnosticsStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleDiagnosticsStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, {
             'result': result
@@ -283,7 +283,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.CHARGING_STATION_DATA_TRANSFER, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_15).handleDataTransfer(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_15).handleDataTransfer(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.CHARGING_STATION_DATA_TRANSFER, {
             'result': result

--- a/src/server/ocpp/soap/services/SoapCentralSystemService16.ts
+++ b/src/server/ocpp/soap/services/SoapCentralSystemService16.ts
@@ -18,7 +18,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleAuthorize(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleAuthorize(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.AUTHORIZE, {
             'result': result
@@ -55,11 +55,11 @@ export default { /* Services */
           headers.ocppProtocol = OCPPProtocol.SOAP;
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleBootNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleBootNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.BOOT_NOTIFICATION, {
             'result': result
@@ -91,7 +91,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.CHARGING_STATION_DATA_TRANSFER, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleDataTransfer(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleDataTransfer(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.CHARGING_STATION_DATA_TRANSFER, {
             'result': result
@@ -119,7 +119,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleDiagnosticsStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleDiagnosticsStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.DIAGNOSTICS_STATUS_NOTIFICATION, {
             'result': result
@@ -143,7 +143,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleFirmwareStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleFirmwareStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.FIRMWARE_STATUS_NOTIFICATION, {
             'result': result
@@ -166,11 +166,11 @@ export default { /* Services */
         Utils.normalizeAndCheckSOAPParams(headers, req).then(async () => {
           // Add current IPs to charging station properties
           headers.currentIPAddress = Utils.getRequestIP(req);
-          headers.currentServerLocalIPAddress = (global.centralSystemSoap.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoap.httpServer.address() as AddressInfo).port;
+          headers.currentServerLocalIPAddress = (global.centralSystemSoapServer.httpServer.address() as AddressInfo).address + ':' + (global.centralSystemSoapServer.httpServer.address() as AddressInfo).port;
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleHeartbeat(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleHeartbeat(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.HEARTBEAT, {
             'result': result
@@ -198,7 +198,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleMeterValues(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleMeterValues(headers, args);
           // Return the result async
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.METER_VALUES, {
             'result': result
@@ -222,7 +222,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleStartTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleStartTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.START_TRANSACTION, {
             'result': result
@@ -256,7 +256,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleStatusNotification(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleStatusNotification(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STATUS_NOTIFICATION, {
             'result': result
@@ -281,7 +281,7 @@ export default { /* Services */
           // Log
           Logging.logReceivedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, [ headers, args ]);
           // Handle
-          const result = await global.centralSystemSoap.getChargingStationService(OCPPVersion.VERSION_16).handleStopTransaction(headers, args);
+          const result = await global.centralSystemSoapServer.getChargingStationService(OCPPVersion.VERSION_16).handleStopTransaction(headers, args);
           // Log
           Logging.logReturnedAction(MODULE_NAME, headers.tenantID, headers.chargeBoxIdentity, ServerAction.STOP_TRANSACTION, {
             'result': result

--- a/src/start.ts
+++ b/src/start.ts
@@ -42,7 +42,7 @@ export default class Bootstrap {
   private static oDataServerConfig: ODataServiceConfiguration;
   private static oDataServer: ODataServer;
   private static databaseDone: boolean;
-  private static database: any;
+  private static database: MongoDBStorage;
   private static migrationConfig: MigrationConfiguration;
   private static migrationDone: boolean;
 
@@ -221,16 +221,16 @@ export default class Bootstrap {
         if (!Bootstrap.centralRestServer) {
           Bootstrap.centralRestServer = new CentralRestServer(Bootstrap.centralSystemRestConfig, Bootstrap.chargingStationConfig);
         }
-        // Create database Web Socket notifications
-        if (!Bootstrap.storageNotification) {
-          Bootstrap.storageNotification = new MongoDBStorageNotification(Bootstrap.storageConfig, Bootstrap.centralRestServer);
-        }
-        // Start database Web Socket notifications
-        Bootstrap.storageNotification.start();
         // Start it
         await Bootstrap.centralRestServer.start();
         // FIXME: Issue with cluster, see https://github.com/LucasBrazi06/ev-server/issues/1097
         if (this.centralSystemRestConfig.socketIO) {
+          // Create database Socket IO notifications
+          if (!Bootstrap.storageNotification) {
+            Bootstrap.storageNotification = new MongoDBStorageNotification(Bootstrap.storageConfig, Bootstrap.centralRestServer);
+          }
+          // Start database Socket IO notifications
+          await Bootstrap.storageNotification.start();
           await this.centralRestServer.startSocketIO();
         }
       }

--- a/src/storage/mongodb/MongoDBStorageNotification.ts
+++ b/src/storage/mongodb/MongoDBStorageNotification.ts
@@ -64,6 +64,13 @@ export default class MongoDBStorageNotification {
     if (this.dbConfig.monitorDBChange) {
       // Check
       if (!this.centralRestServer) {
+        // Log
+        Logging.logError({
+          tenantID: Constants.DEFAULT_TENANT,
+          action: ServerAction.STARTUP,
+          module: MODULE_NAME, method: 'start',
+          message: `Error starting to monitor changes on database '${this.dbConfig.implementation}': REST server attribute not initialized`
+        });
         return;
       }
 

--- a/src/types/GlobalType.ts
+++ b/src/types/GlobalType.ts
@@ -25,8 +25,8 @@ export interface ActionsResponse {
 interface TSGlobal extends Global {
   database: MongoDBStorage;
   appRoot: string;
-  centralSystemJson: JsonCentralSystemServer;
-  centralSystemSoap: SoapCentralSystemServer;
+  centralSystemJsonServer: JsonCentralSystemServer;
+  centralSystemSoapServer: SoapCentralSystemServer;
   userHashMapIDs: Map<string, string>;
   tenantHashMapIDs: Map<string, string>;
 }


### PR DESCRIPTION
server is disabled.

The buffer was never emptied and it probably has cause huge memory
comsuption triggering crash in the past.

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>