### PR TITLE
socket.io: force server side connection close with no callback on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ev-server",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/server/rest/CentralRestServer.ts
+++ b/src/server/rest/CentralRestServer.ts
@@ -124,6 +124,8 @@ export default class CentralRestServer {
       secret: Configuration.getCentralSystemRestServiceConfig().userTokenKey,
       handshake: true,
       decodedPropertyName: 'decoded_token',
+      // No client-side callback, terminate connection server-side
+      callback: false
     }));
     // Handle Socket IO connection
     CentralRestServer.socketIOServer.on('connection', (socket: SocketIOJwt) => {


### PR DESCRIPTION
invalid jwt token.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>