### PR TITLE
Templates: keep track of unmatched template sections. 

### DIFF
--- a/src/migration/tasks/UpdateChargingStationStaticLimitationTask.ts
+++ b/src/migration/tasks/UpdateChargingStationStaticLimitationTask.ts
@@ -81,8 +81,7 @@ export default class UpdateChargingStationStaticLimitationTask extends Migration
               // Get max connector amps
               const connector = Utils.getConnectorFromID(chargingStation, connectorID);
               if (connector) {
-                const amperageConnectorMax = Utils.getChargingStationAmperage(chargingStation, chargePoint, connectorID);
-                connector.amperageLimit = amperageConnectorMax;
+                connector.amperageLimit = Utils.getChargingStationAmperage(chargingStation, chargePoint, connectorID);
               }
             }
             await ChargingStationStorage.saveChargingStation(tenant.id, chargingStation);

--- a/src/scheduler/tasks/CheckChargingStationTemplateTask.ts
+++ b/src/scheduler/tasks/CheckChargingStationTemplateTask.ts
@@ -67,11 +67,12 @@ export default class CheckChargingStationTemplateTask extends SchedulerTask {
         // Check Connectors
         for (const connector of chargingStation.connectors) {
           // Amperage limit
+          const connectorAmperageLimit = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
           if (!Utils.objectHasProperty(connector, 'amperageLimit')) {
-            connector.amperageLimit = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
+            connector.amperageLimit = connectorAmperageLimit;
             chargingStationUpdated = true;
-          } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit > Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId)) {
-            connector.amperageLimit = Utils.getChargingStationAmperage(chargingStation, null, connector.connectorId);
+          } else if (Utils.objectHasProperty(connector, 'amperageLimit') && connector.amperageLimit > connectorAmperageLimit) {
+            connector.amperageLimit = connectorAmperageLimit;
             chargingStationUpdated = true;
           }
           // Phase Assignment
@@ -101,11 +102,11 @@ export default class CheckChargingStationTemplateTask extends SchedulerTask {
           if (chargingStationTemplateUpdated.technicalUpdated) {
             sectionsUpdated.push('Technical');
           }
-          if (chargingStationTemplateUpdated.ocppUpdated) {
-            sectionsUpdated.push('OCPP');
-          }
           if (chargingStationTemplateUpdated.capabilitiesUpdated) {
             sectionsUpdated.push('Capabilities');
+          }
+          if (chargingStationTemplateUpdated.ocppUpdated) {
+            sectionsUpdated.push('OCPP');
           }
           Logging.logInfo({
             tenantID: tenant.id,

--- a/src/server/ocpp/utils/OCPPUtils.ts
+++ b/src/server/ocpp/utils/OCPPUtils.ts
@@ -1181,11 +1181,11 @@ export default class OCPPUtils {
       });
       return templateUpdateResult;
     }
-    let logMsg: string;
+    let noTemplateMatchingLogMsg: string;
     if (chargingStation.templateHash) {
-      logMsg = 'No template matching the charging station has been found but one matched previously. Keeping the previous template configuration';
+      noTemplateMatchingLogMsg = 'No template matching the charging station has been found but one matched previously. Keeping the previous template configuration';
     } else {
-      logMsg = 'No template matching the charging station has been found';
+      noTemplateMatchingLogMsg = 'No template matching the charging station has been found';
     }
     // Log
     Logging.logWarning({
@@ -1193,7 +1193,7 @@ export default class OCPPUtils {
       source: chargingStation.id,
       action: ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
       module: MODULE_NAME, method: 'enrichChargingStationWithTemplate',
-      message: logMsg,
+      message: noTemplateMatchingLogMsg,
       detailedMessages: { chargingStation }
     });
     return templateUpdateResult;
@@ -1216,7 +1216,7 @@ export default class OCPPUtils {
             source: chargingStation.id,
             action: ServerAction.UPDATE_CHARGING_STATION_WITH_TEMPLATE,
             module: MODULE_NAME, method: 'enrichChargingStationConnectorWithTemplate',
-            message: `No Connector found in Template for Connector ID '${connectorID}' on '${chargingStation.chargePointVendor}'`
+            message: `No connector found in Template for Connector ID '${connectorID}' on '${chargingStation.chargePointVendor}'`
           });
           return false;
         }
@@ -1270,7 +1270,8 @@ export default class OCPPUtils {
                 }
               }
             }
-            return true;
+            // Template on connector id = connectorID applied, break the loop to continue the static method execution. Never return here.
+            break;
           }
         }
       }

--- a/src/server/rest/CentralRestServer.ts
+++ b/src/server/rest/CentralRestServer.ts
@@ -456,7 +456,7 @@ export default class CentralRestServer {
         }
       }
       if (!dups) {
-      // Add it
+        // Add it
         CentralRestServer.singleChangeNotifications.push(notification);
       }
     }

--- a/src/start.ts
+++ b/src/start.ts
@@ -191,7 +191,7 @@ export default class Bootstrap {
 
   private static startMaster(): void {
     try {
-      if (Bootstrap.isClusterEnabled && Utils.isEmptyArray(cluster.workers)) {
+      if (Bootstrap.isClusterEnabled && Utils.isEmptyObject(cluster.workers)) {
         Bootstrap.startServerWorkers('Main');
       }
     } catch (error) {

--- a/src/types/requests/HttpDatabaseRequest.ts
+++ b/src/types/requests/HttpDatabaseRequest.ts
@@ -3,6 +3,6 @@ export default interface HttpDatabaseRequest {
   Limit: number;
   OnlyRecordCount?: boolean;
   SortFields: string[];
-  SortDirs: string[]; // TODO: Deprecated: remote it
+  SortDirs: string[]; // TODO: Deprecated: remove it
   Sort: any;
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -975,7 +975,7 @@ export default class Utils {
     return amperageLimit;
   }
 
-  public static isEmptyArray(array: any): boolean {
+  public static isEmptyArray(array: any[]): boolean {
     if (!array) {
       return true;
     }
@@ -983,6 +983,10 @@ export default class Utils {
       return false;
     }
     return true;
+  }
+
+  static isEmptyObject(obj: any): boolean {
+    return !Object.keys(obj).length;
   }
 
   public static findDuplicatesInArray(arr: any[]): any[] {


### PR DESCRIPTION
+ Only set sections hash if there's a match;
+ Logic fix for template application at the connector level;
+ Enhance logging for the no template matching CS case.