### PR TITLE
Improve WebSocket events logging to help debugging.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17442,9 +17442,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.13.tgz",
-      "integrity": "sha512-1o1nO6aqouA23d2nlcMSEyPMAWRhnYUU0EQUJSc60E0TUyBNX792RHFYUN1ZM29vhMUNayrsbj2UVdZwKhXCDA==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.12.tgz",
+      "integrity": "sha512-UIivVfGVJDdwwjgSrbtcL9Nf10c1BWnL1mxAQUVcnhNIn/P9W3nP5v60Z0aBMtc7ZrE11lMmU6+5jSgAXmGaYw==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17442,9 +17442,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "8.0.12",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.12.tgz",
-      "integrity": "sha512-UIivVfGVJDdwwjgSrbtcL9Nf10c1BWnL1mxAQUVcnhNIn/P9W3nP5v60Z0aBMtc7ZrE11lMmU6+5jSgAXmGaYw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.13.tgz",
+      "integrity": "sha512-1o1nO6aqouA23d2nlcMSEyPMAWRhnYUU0EQUJSc60E0TUyBNX792RHFYUN1ZM29vhMUNayrsbj2UVdZwKhXCDA==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -18695,9 +18695,9 @@
       }
     },
     "ws": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "querystring": "^0.2.0",
     "rimraf": "^3.0.2",
     "rosie": "^2.0.1",
-    "ts-loader": "^8.0.13",
+    "ts-loader": "^8.0.12",
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "urlencode": "^1.1.0",
     "uuid": "^8.3.2",
     "validator": "^13.1.17",
-    "ws": "^7.4.1"
+    "ws": "^7.4.2"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.2",
@@ -208,7 +208,7 @@
     "querystring": "^0.2.0",
     "rimraf": "^3.0.2",
     "rosie": "^2.0.1",
-    "ts-loader": "^8.0.12",
+    "ts-loader": "^8.0.13",
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.1",
     "typescript": "^4.1.3",

--- a/src/client/ocpp/ChargingStationClientFactory.ts
+++ b/src/client/ocpp/ChargingStationClientFactory.ts
@@ -29,7 +29,7 @@ export default class ChargingStationClientFactory {
           // Not Found
           if (!chargingClient) {
             // Use the remote client
-            chargingClient = new JsonRestChargingStationClient(tenantID, chargingStation, Utils.isProductionEnv());
+            chargingClient = new JsonRestChargingStationClient(tenantID, chargingStation);
           }
           break;
         // SOAP

--- a/src/client/ocpp/ChargingStationClientFactory.ts
+++ b/src/client/ocpp/ChargingStationClientFactory.ts
@@ -29,7 +29,7 @@ export default class ChargingStationClientFactory {
           // Not Found
           if (!chargingClient) {
             // Use the remote client
-            chargingClient = new JsonRestChargingStationClient(tenantID, chargingStation);
+            chargingClient = new JsonRestChargingStationClient(tenantID, chargingStation, Utils.isProductionEnv());
           }
           break;
         // SOAP

--- a/src/client/ocpp/json/JsonChargingStationClient.ts
+++ b/src/client/ocpp/json/JsonChargingStationClient.ts
@@ -4,7 +4,7 @@ import ChargingStationClient from '../../ocpp/ChargingStationClient';
 import { Command } from '../../../types/ChargingStation';
 import JsonWSConnection from '../../../server/ocpp/json/JsonWSConnection';
 import Logging from '../../../utils/Logging';
-import { MessageType } from '../../../types/WebSocket';
+import { OCPPMessageType } from '../../../types/ocpp/OCPPCommon';
 import { ServerAction } from '../../../types/Server';
 import Utils from '../../../utils/Utils';
 
@@ -31,58 +31,58 @@ export default class JsonChargingStationClient extends ChargingStationClient {
   }
 
   public async remoteStartTransaction(params: OCPPRemoteStartTransactionCommandParam): Promise<OCPPRemoteStartTransactionCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.REMOTE_START_TRANSACTION);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.REMOTE_START_TRANSACTION);
   }
 
   public async reset(params: OCPPResetCommandParam): Promise<OCPPResetCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.RESET);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.RESET);
   }
 
   public async clearCache(): Promise<OCPPClearCacheCommandResult> {
-    return this.sendMessage({}, MessageType.CALL_MESSAGE, Command.CLEAR_CACHE);
+    return this.sendMessage({}, OCPPMessageType.CALL_MESSAGE, Command.CLEAR_CACHE);
   }
 
   public async getConfiguration(params: OCPPGetConfigurationCommandParam = {}): Promise<OCPPGetConfigurationCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.GET_CONFIGURATION);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.GET_CONFIGURATION);
   }
 
   public async changeConfiguration(params: OCPPChangeConfigurationCommandParam): Promise<OCPPChangeConfigurationCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.CHANGE_CONFIGURATION);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.CHANGE_CONFIGURATION);
   }
 
   public async remoteStopTransaction(params: OCPPRemoteStopTransactionCommandParam): Promise<OCPPRemoteStopTransactionCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.REMOTE_STOP_TRANSACTION);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.REMOTE_STOP_TRANSACTION);
   }
 
   public async unlockConnector(params: OCPPUnlockConnectorCommandParam): Promise<OCPPUnlockConnectorCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.UNLOCK_CONNECTOR);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.UNLOCK_CONNECTOR);
   }
 
   public async setChargingProfile(params: OCPPSetChargingProfileCommandParam): Promise<OCPPSetChargingProfileCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.SET_CHARGING_PROFILE);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.SET_CHARGING_PROFILE);
   }
 
   public async getCompositeSchedule(params: OCPPGetCompositeScheduleCommandParam): Promise<OCPPGetCompositeScheduleCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.GET_COMPOSITE_SCHEDULE);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.GET_COMPOSITE_SCHEDULE);
   }
 
   public async clearChargingProfile(params: OCPPClearChargingProfileCommandParam): Promise<OCPPClearChargingProfileCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.CLEAR_CHARGING_PROFILE);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.CLEAR_CHARGING_PROFILE);
   }
 
   public async changeAvailability(params: OCPPChangeAvailabilityCommandParam): Promise<OCPPChangeAvailabilityCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.CHANGE_AVAILABILITY);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.CHANGE_AVAILABILITY);
   }
 
   public async getDiagnostics(params: OCPPGetDiagnosticsCommandParam): Promise<OCPPGetDiagnosticsCommandResult> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.GET_DIAGNOSTICS);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.GET_DIAGNOSTICS);
   }
 
   public async updateFirmware(params: OCPPUpdateFirmwareCommandParam): Promise<void> {
-    return this.sendMessage(params, MessageType.CALL_MESSAGE, Command.UPDATE_FIRMWARE);
+    return this.sendMessage(params, OCPPMessageType.CALL_MESSAGE, Command.UPDATE_FIRMWARE);
   }
 
-  private async sendMessage(params: any, messageType: MessageType, commandName: Command): Promise<any> {
+  private async sendMessage(params: any, messageType: OCPPMessageType, commandName: Command): Promise<any> {
     // Log
     Logging.logChargingStationClientSendAction(MODULE_NAME, this.tenantID, this.chargingStationID, `ChargingStation${commandName}` as ServerAction, params);
     // Execute

--- a/src/client/ocpp/json/JsonRestChargingStationClient.ts
+++ b/src/client/ocpp/json/JsonRestChargingStationClient.ts
@@ -96,7 +96,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
       module: MODULE_NAME, method: 'onOpen',
       message: `Try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`
     });
-    Utils.isDevelopmentEnv() && console.log(`REST client try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`);
 
     // Create Promise
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -130,7 +129,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
           module: MODULE_NAME, method: 'onOpen',
           message: `Connection opened to '${this.serverURL}'`
         });
-        Utils.isDevelopmentEnv() && console.log(`REST client connection opened to '${this.serverURL}'`);
         // Connection is opened and ready to use
         resolve();
       };
@@ -144,19 +142,18 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
           module: MODULE_NAME, method: 'onClose',
           message: `Connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`
         });
-        Utils.isDevelopmentEnv() && console.log(`REST client connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
       };
       // Handle Error Message
       this.wsConnection.onerror = (error: Error) => {
         // Log
-        Logging.logException(
-          error,
-          ServerAction.WS_REST_CLIENT_CONNECTION_ERROR,
-          this.chargingStation.id,
-          MODULE_NAME, 'onError',
-          this.tenantID
-        );
-        Utils.isDevelopmentEnv() && console.exception(`REST client connection error to '${this.serverURL}:`, error);
+        Logging.logError({
+          tenantID: this.tenantID,
+          source: this.chargingStation.id,
+          action: ServerAction.WS_REST_CLIENT_CONNECTION_ERROR,
+          module: MODULE_NAME, method: 'onError',
+          message: `Connection error to '${this.serverURL}: ${error}`,
+          detailedMessages: { error }
+        });
         // Terminate WS in error
         this.terminateConnection();
       };
@@ -178,7 +175,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
                 message: `${messageJson[3]}`,
                 detailedMessages: { messageJson }
               });
-              Utils.isDevelopmentEnv() && console.error(`REST client message response error ${messageJson[3]}:`, messageJson);
               // Resolve with error message
               this.requests[messageJson[1]].reject({ status: 'Rejected', error: messageJson });
             } else {
@@ -198,7 +194,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
               message: 'Received unknown message',
               detailedMessages: { messageJson }
             });
-            Utils.isDevelopmentEnv() && console.error('REST client received unknown message:', messageJson);
           }
         } catch (error) {
           // Log
@@ -209,7 +204,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
             MODULE_NAME, 'onMessage',
             this.tenantID
           );
-          Utils.isDevelopmentEnv() && console.exception('REST client message error:', error);
         }
       };
     });

--- a/src/client/ocpp/json/JsonRestChargingStationClient.ts
+++ b/src/client/ocpp/json/JsonRestChargingStationClient.ts
@@ -18,12 +18,10 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
   private requests: { [messageUID: string]: { resolve?: (result: Record<string, unknown>) => void; reject?: (error: Record<string, unknown>) => void; command: ServerAction } };
   private wsConnection: WSClient;
   private tenantID: string;
-  private dbLogging: boolean;
 
-  constructor(tenantID: string, chargingStation: ChargingStation, dbLogging = true) {
+  constructor(tenantID: string, chargingStation: ChargingStation) {
     super();
     this.tenantID = tenantID;
-    this.dbLogging = dbLogging;
     // Get URL
     let chargingStationURL: string = chargingStation.chargingStationURL;
     // Check URL: remove starting and trailing '/'
@@ -91,17 +89,15 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
 
   private async openConnection(): Promise<unknown> {
     // Log
-    if (this.dbLogging) {
-      Logging.logInfo({
-        tenantID: this.tenantID,
-        source: this.chargingStation.id,
-        action: ServerAction.WS_REST_CLIENT_CONNECTION_OPENED,
-        module: MODULE_NAME, method: 'onOpen',
-        message: `Try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`
-      });
-    } else {
-      console.log(`REST client try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`);
-    }
+    Logging.logInfo({
+      tenantID: this.tenantID,
+      source: this.chargingStation.id,
+      action: ServerAction.WS_REST_CLIENT_CONNECTION_OPENED,
+      module: MODULE_NAME, method: 'onOpen',
+      message: `Try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`
+    });
+    Utils.isDevelopmentEnv() && console.log(`REST client try to connect to '${this.serverURL}' ${Configuration.isCloudFoundry() ? ', CF Instance \'' + this.chargingStation.cfApplicationIDAndInstanceIndex + '\'' : ''}`);
+
     // Create Promise
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return await new Promise((resolve, reject) => {
@@ -123,53 +119,44 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
         autoReconnectMaxRetries: Configuration.getWSClientConfig().autoReconnectMaxRetries,
         logTenantID: this.tenantID
       };
-      this.wsConnection = new WSClient(this.serverURL, wsClientOptions, this.dbLogging);
+      this.wsConnection = new WSClient(this.serverURL, wsClientOptions);
       // Opened
       this.wsConnection.onopen = () => {
         // Log
-        if (this.dbLogging) {
-          Logging.logInfo({
-            tenantID: this.tenantID,
-            source: this.chargingStation.id,
-            action: ServerAction.WS_REST_CLIENT_CONNECTION_OPENED,
-            module: MODULE_NAME, method: 'onOpen',
-            message: `Connection opened to '${this.serverURL}'`
-          });
-        } else {
-          console.log(`REST client connection opened to '${this.serverURL}'`);
-        }
+        Logging.logInfo({
+          tenantID: this.tenantID,
+          source: this.chargingStation.id,
+          action: ServerAction.WS_REST_CLIENT_CONNECTION_OPENED,
+          module: MODULE_NAME, method: 'onOpen',
+          message: `Connection opened to '${this.serverURL}'`
+        });
+        Utils.isDevelopmentEnv() && console.log(`REST client connection opened to '${this.serverURL}'`);
         // Connection is opened and ready to use
         resolve();
       };
       // Closed
       this.wsConnection.onclose = (code: number) => {
         // Log
-        if (this.dbLogging) {
-          Logging.logInfo({
-            tenantID: this.tenantID,
-            source: this.chargingStation.id,
-            action: ServerAction.WS_REST_CLIENT_CONNECTION_CLOSED,
-            module: MODULE_NAME, method: 'onClose',
-            message: `Connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`
-          });
-        } else {
-          console.log(`REST client connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
-        }
+        Logging.logInfo({
+          tenantID: this.tenantID,
+          source: this.chargingStation.id,
+          action: ServerAction.WS_REST_CLIENT_CONNECTION_CLOSED,
+          module: MODULE_NAME, method: 'onClose',
+          message: `Connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`
+        });
+        Utils.isDevelopmentEnv() && console.log(`REST client connection closed to '${this.serverURL}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
       };
       // Handle Error Message
       this.wsConnection.onerror = (error: Error) => {
         // Log
-        if (this.dbLogging) {
-          Logging.logException(
-            error,
-            ServerAction.WS_REST_CLIENT_CONNECTION_ERROR,
-            this.chargingStation.id,
-            MODULE_NAME, 'onError',
-            this.tenantID
-          );
-        } else {
-          console.exception(`REST client connection error to '${this.serverURL}:`, error);
-        }
+        Logging.logException(
+          error,
+          ServerAction.WS_REST_CLIENT_CONNECTION_ERROR,
+          this.chargingStation.id,
+          MODULE_NAME, 'onError',
+          this.tenantID
+        );
+        Utils.isDevelopmentEnv() && console.exception(`REST client connection error to '${this.serverURL}:`, error);
         // Terminate WS in error
         this.terminateConnection();
       };
@@ -183,18 +170,15 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
             // Check message type
             if (messageJson[0] === OCPPMessageType.CALL_ERROR_MESSAGE) {
               // Error message
-              if (this.dbLogging) {
-                Logging.logError({
-                  tenantID: this.tenantID,
-                  source: this.chargingStation.id,
-                  action: ServerAction.WS_REST_CLIENT_ERROR_RESPONSE,
-                  module: MODULE_NAME, method: 'onMessage',
-                  message: `${messageJson[3]}`,
-                  detailedMessages: { messageJson }
-                });
-              } else {
-                console.error(`REST client message response error ${messageJson[3]}:`, messageJson);
-              }
+              Logging.logError({
+                tenantID: this.tenantID,
+                source: this.chargingStation.id,
+                action: ServerAction.WS_REST_CLIENT_ERROR_RESPONSE,
+                module: MODULE_NAME, method: 'onMessage',
+                message: `${messageJson[3]}`,
+                detailedMessages: { messageJson }
+              });
+              Utils.isDevelopmentEnv() && console.error(`REST client message response error ${messageJson[3]}:`, messageJson);
               // Resolve with error message
               this.requests[messageJson[1]].reject({ status: 'Rejected', error: messageJson });
             } else {
@@ -206,31 +190,27 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
           } else {
             // Error message
             // eslint-disable-next-line no-lonely-if
-            if (this.dbLogging) {
-              Logging.logError({
-                tenantID: this.tenantID,
-                source: this.chargingStation.id,
-                action: ServerAction.WS_REST_CLIENT_ERROR_RESPONSE,
-                module: MODULE_NAME, method: 'onMessage',
-                message: 'Received unknown message',
-                detailedMessages: { messageJson }
-              });
-            } else {
-              console.error('REST client received unknown message:', messageJson);
-            }
+            Logging.logError({
+              tenantID: this.tenantID,
+              source: this.chargingStation.id,
+              action: ServerAction.WS_REST_CLIENT_ERROR_RESPONSE,
+              module: MODULE_NAME, method: 'onMessage',
+              message: 'Received unknown message',
+              detailedMessages: { messageJson }
+            });
+            Utils.isDevelopmentEnv() && console.error('REST client received unknown message:', messageJson);
           }
         } catch (error) {
           // Log
-          if (this.dbLogging) {
-            Logging.logException(
-              error,
-              ServerAction.WS_REST_CLIENT_MESSAGE,
-              this.chargingStation.id,
-              MODULE_NAME, 'onMessage',
-              this.tenantID);
-          } else {
-            console.exception('REST client message error:', error);
-          }
+          Logging.logException(
+            error,
+            ServerAction.WS_REST_CLIENT_MESSAGE,
+            this.chargingStation.id,
+            MODULE_NAME, 'onMessage',
+            this.tenantID
+          );
+          Utils.isDevelopmentEnv() && console.exception('REST client message error:', error);
+
         }
       };
     });

--- a/src/client/ocpp/json/JsonRestChargingStationClient.ts
+++ b/src/client/ocpp/json/JsonRestChargingStationClient.ts
@@ -210,7 +210,6 @@ export default class JsonRestChargingStationClient extends ChargingStationClient
             this.tenantID
           );
           Utils.isDevelopmentEnv() && console.exception('REST client message error:', error);
-
         }
       };
     });

--- a/src/client/websocket/WSClient.ts
+++ b/src/client/websocket/WSClient.ts
@@ -149,7 +149,7 @@ export default class WSClient {
           });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`WSClient reconnection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`);
+          (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.log(`WSClient reconnection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`);
         }
         this.onreconnect(error);
         this.open();
@@ -165,7 +165,7 @@ export default class WSClient {
         });
       } else {
         // eslint-disable-next-line no-console
-        console.log(`WSClient reconnection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`);
+        (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.log(`WSClient reconnection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`);
       }
       this.onmaximum(error);
     }
@@ -197,7 +197,7 @@ export default class WSClient {
           });
         } else {
           // eslint-disable-next-line no-console
-          console.error(`WSClient connection refused to '${this.url}':`, error);
+          (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.error(`WSClient connection refused to '${this.url}':`, error);
         }
         // pragma this.reconnect(error);
         break;
@@ -213,7 +213,7 @@ export default class WSClient {
           });
         } else {
           // eslint-disable-next-line no-console
-          console.error(`WSClient connection error to '${this.url}':`, error);
+          (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.error(`WSClient connection error to '${this.url}':`, error);
         }
         break;
     }
@@ -233,7 +233,7 @@ export default class WSClient {
           });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`WSClient connection closing to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
+          (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.log(`WSClient connection closing to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
         }
         this.autoReconnectRetryCount = 0;
         break;
@@ -248,7 +248,7 @@ export default class WSClient {
           });
         } else {
           // eslint-disable-next-line no-console
-          console.error(`WSClient Connection closing error to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
+          (Utils.isDevelopmentEnv() || Utils.isTestEnv()) && console.error(`WSClient Connection closing error to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
         }
         this.reconnect(new Error(`Connection has been closed abnormally, Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`));
         break;

--- a/src/client/websocket/WSClient.ts
+++ b/src/client/websocket/WSClient.ts
@@ -1,8 +1,9 @@
+import { WSClientOptions, WebSocketCloseEventStatusCode } from '../../types/WebSocket';
+
 import Constants from '../../utils/Constants';
 import Logging from '../../utils/Logging';
 import { ServerAction } from '../../types/Server';
 import Utils from '../../utils/Utils';
-import { WSClientOptions } from '../../types/WebSocket';
 import WebSocket from 'ws';
 import axiosRetry from 'axios-retry';
 
@@ -15,7 +16,6 @@ export default class WSClient {
   public onmessage: (...args: any[]) => void;
   public onmaximum: (err: Error) => void;
   public onreconnect: (err: Error) => void;
-  public readyState: number;
   private url: string;
   private options: WSClientOptions;
   private callbacks: { [key: string]: (...args: any[]) => void };
@@ -130,7 +130,7 @@ export default class WSClient {
   }
 
   public isConnectionOpen(): boolean {
-    return this.ws.readyState === WebSocket.OPEN;
+    return this.ws?.readyState === WebSocket.OPEN;
   }
 
   private reconnect(error: Error): void {
@@ -139,33 +139,33 @@ export default class WSClient {
       this.autoReconnectRetryCount++;
       Utils.sleep(axiosRetry.exponentialDelay(this.autoReconnectRetryCount)).catch(() => { });
       setTimeout(() => {
+        // Informational message
         if (this.dbLogging) {
-          // Informational message
           Logging.logInfo({
             tenantID: this.logTenantID,
             module: MODULE_NAME, method: 'reconnect',
             action: ServerAction.WS_CLIENT_INFO,
-            message: `Re-connection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`
+            message: `Reconnection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`
           });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`Re-connection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`);
+          console.log(`WSClient reconnection try #${this.autoReconnectRetryCount} to '${this.url}' with timeout ${this.autoReconnectTimeout}ms`);
         }
         this.onreconnect(error);
         this.open();
       }, this.autoReconnectTimeout);
     } else if (this.autoReconnectTimeout !== Constants.WS_RECONNECT_DISABLED || this.autoReconnectMaxRetries !== Constants.WS_RECONNECT_UNLIMITED) {
+      // Informational message
       if (this.dbLogging) {
-        // Informational message
         Logging.logInfo({
           tenantID: this.logTenantID,
           module: MODULE_NAME, method: 'reconnect',
           action: ServerAction.WS_CLIENT_INFO,
-          message: `Re-connection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`
+          message: `Reconnection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`
         });
       } else {
         // eslint-disable-next-line no-console
-        console.log(`Re-connection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`);
+        console.log(`WSClient reconnection maximum retries reached (${this.autoReconnectRetryCount}) or disabled (${this.autoReconnectTimeout}) to '${this.url}'`);
       }
       this.onmaximum(error);
     }
@@ -186,34 +186,34 @@ export default class WSClient {
   private onError(error: Error) {
     switch (error.toString()) {
       case 'ECONNREFUSED':
+        // Error message
         if (this.dbLogging) {
-          // Error message
           Logging.logError({
             tenantID: this.logTenantID,
             module: MODULE_NAME, method: 'onError',
             action: ServerAction.WS_CLIENT_ERROR,
-            message: `Connection refused to '${this.url}': ${error}`
+            message: `Connection refused to '${this.url}': ${error}`,
+            detailedMessages: { error }
           });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`Connection refused to '${this.url}':`, error);
+          console.error(`WSClient connection refused to '${this.url}':`, error);
         }
-        this.reconnect(error);
+        // pragma this.reconnect(error);
         break;
       default:
+        // Error message
         if (this.dbLogging) {
-          if (Utils.isProductionEnv()) {
-            // Error message
-            Logging.logError({
-              tenantID: this.logTenantID,
-              module: MODULE_NAME, method: 'onError',
-              action: ServerAction.WS_CLIENT_ERROR,
-              message: `Connection error to '${this.url}': ${error}`
-            });
-          }
+          Logging.logError({
+            tenantID: this.logTenantID,
+            module: MODULE_NAME, method: 'onError',
+            action: ServerAction.WS_CLIENT_ERROR,
+            message: `Connection error to '${this.url}': ${error}`,
+            detailedMessages: { error }
+          });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`Connection error to '${this.url}':`, error);
+          console.error(`WSClient connection error to '${this.url}':`, error);
         }
         break;
     }
@@ -221,26 +221,36 @@ export default class WSClient {
 
   private onClose(code: number, reason: string) {
     switch (code) {
-      case 1000: // Normal close
-      case 1005:
+      case WebSocketCloseEventStatusCode.CLOSE_NORMAL: // Normal close
+      case WebSocketCloseEventStatusCode.CLOSE_NO_STATUS:
+        // Informational message
+        if (this.dbLogging) {
+          Logging.logInfo({
+            tenantID: this.logTenantID,
+            module: MODULE_NAME, method: 'onClose',
+            action: ServerAction.WS_CLIENT_INFO,
+            message: `Connection closing to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`
+          });
+        } else {
+          // eslint-disable-next-line no-console
+          console.log(`WSClient connection closing to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
+        }
         this.autoReconnectRetryCount = 0;
         break;
       default: // Abnormal close
+        // Error message
         if (this.dbLogging) {
-          if (Utils.isProductionEnv()) {
-            // Error message
-            Logging.logError({
-              tenantID: this.logTenantID,
-              module: MODULE_NAME, method: 'onClose',
-              action: ServerAction.WS_CLIENT_ERROR,
-              message: `Connection closing error to '${this.url}': ${code}`
-            });
-          }
+          Logging.logError({
+            tenantID: this.logTenantID,
+            module: MODULE_NAME, method: 'onClose',
+            action: ServerAction.WS_CLIENT_ERROR,
+            message: `Connection closing error to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`
+          });
         } else {
           // eslint-disable-next-line no-console
-          console.log(`Connection closing error to '${this.url}':`, code);
+          console.error(`WSClient Connection closing error to '${this.url}', Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`);
         }
-        this.reconnect(new Error(`Connection has been closed, Reason '${reason ? reason : 'No reason given'}', Code '${code}'`));
+        this.reconnect(new Error(`Connection has been closed abnormally, Reason: '${reason ? reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(code)}', Code: '${code}'`));
         break;
     }
   }

--- a/src/migration/MigrationHandler.ts
+++ b/src/migration/MigrationHandler.ts
@@ -198,7 +198,7 @@ export default class MigrationHandler {
         message: logMsg,
         detailedMessages: { error: error.message, stack: error.stack }
       });
-      console.log(logMsg);
+      console.error(logMsg);
     }
   }
 }

--- a/src/server/ocpp/json/JsonCentralSystemServer.ts
+++ b/src/server/ocpp/json/JsonCentralSystemServer.ts
@@ -10,6 +10,7 @@ import JsonWSConnection from './JsonWSConnection';
 import Logging from '../../../utils/Logging';
 import { ServerAction } from '../../../types/Server';
 import WSServer from './WSServer';
+import { WebSocketCloseEventStatusCode } from '../../../types/WebSocket';
 import global from '../../../types/GlobalType';
 import http from 'http';
 
@@ -164,7 +165,7 @@ export default class JsonCentralSystemServer extends CentralSystemServer {
         Logging.logException(
           error, ServerAction.WS_CONNECTION, '', MODULE_NAME, 'connection', Constants.DEFAULT_TENANT);
         // Respond
-        ws.close(Constants.WS_UNSUPPORTED_DATA, error.message);
+        ws.close(WebSocketCloseEventStatusCode.CLOSE_UNSUPPORTED, error.message);
       }
     });
     // Keep alive WebSocket connection

--- a/src/server/ocpp/json/JsonRestWSConnection.ts
+++ b/src/server/ocpp/json/JsonRestWSConnection.ts
@@ -5,8 +5,9 @@ import ChargingStationClient from '../../../client/ocpp/ChargingStationClient';
 import ChargingStationStorage from '../../../storage/mongodb/ChargingStationStorage';
 import JsonCentralSystemServer from './JsonCentralSystemServer';
 import Logging from '../../../utils/Logging';
-import { MessageType } from '../../../types/WebSocket';
+import { OCPPMessageType } from '../../../types/ocpp/OCPPCommon';
 import { ServerAction } from '../../../types/Server';
+import Utils from '../../../utils/Utils';
 import WSConnection from './WSConnection';
 import global from '../../../types/GlobalType';
 import http from 'http';
@@ -56,7 +57,7 @@ export default class JsonRestWSConnection extends WSConnection {
       source: (this.getChargingStationID() ? this.getChargingStationID() : ''),
       module: MODULE_NAME, method: 'onClose',
       action: ServerAction.WS_REST_CONNECTION_CLOSED,
-      message: `Connection has been closed, Reason '${closeEvent.reason ? closeEvent.reason : 'No reason given'}', Code '${closeEvent}'`,
+      message: `Connection has been closed, Reason: '${closeEvent.reason ? closeEvent.reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(Utils.convertToInt(closeEvent))}', Code: '${closeEvent.toString()}'`,
       detailedMessages: { closeEvent: closeEvent }
     });
     // Remove the connection
@@ -93,7 +94,7 @@ export default class JsonRestWSConnection extends WSConnection {
       // Call the method
       const result = await chargingStationClient[actionMethod](commandPayload);
       // Send Response
-      await this.sendMessage(messageId, result, MessageType.CALL_RESULT_MESSAGE, commandName);
+      await this.sendMessage(messageId, result, OCPPMessageType.CALL_RESULT_MESSAGE, commandName);
     } else {
       // Error
       throw new BackendError({

--- a/src/server/ocpp/json/JsonWSConnection.ts
+++ b/src/server/ocpp/json/JsonWSConnection.ts
@@ -1,4 +1,4 @@
-import { MessageType, OcppErrorType } from '../../../types/WebSocket';
+import { OCPPErrorType, OCPPMessageType } from '../../../types/ocpp/OCPPCommon';
 import { OCPPProtocol, OCPPVersion } from '../../../types/ocpp/OCPPServer';
 import WebSocket, { CloseEvent, ErrorEvent } from 'ws';
 
@@ -14,6 +14,7 @@ import Logging from '../../../utils/Logging';
 import OCPPError from '../../../exception/OcppError';
 import { OCPPHeader } from '../../../types/ocpp/OCPPHeader';
 import { ServerAction } from '../../../types/Server';
+import Utils from '../../../utils/Utils';
 import WSConnection from './WSConnection';
 import http from 'http';
 
@@ -103,7 +104,7 @@ export default class JsonWSConnection extends WSConnection {
       source: (this.getChargingStationID() ? this.getChargingStationID() : ''),
       action: ServerAction.WS_JSON_CONNECTION_CLOSED,
       module: MODULE_NAME, method: 'onClose',
-      message: `Connection has been closed, Reason '${closeEvent.reason ? closeEvent.reason : 'No reason given'}', Code '${closeEvent}'`,
+      message: `Connection has been closed, Reason: '${closeEvent.reason ? closeEvent.reason : 'No reason given'}', Message: '${Utils.getWebSocketCloseEventStatusString(Utils.convertToInt(closeEvent))}', Code: '${closeEvent.toString()}'`,
       detailedMessages: { closeEvent: closeEvent }
     });
     // Remove the connection
@@ -132,14 +133,14 @@ export default class JsonWSConnection extends WSConnection {
       // Log
       Logging.logChargingStationServerRespondAction(MODULE_NAME, this.getTenantID(), this.getChargingStationID(), commandName, result);
       // Send Response
-      await this.sendMessage(messageId, result, MessageType.CALL_RESULT_MESSAGE, commandName);
+      await this.sendMessage(messageId, result, OCPPMessageType.CALL_RESULT_MESSAGE, commandName);
     } else {
       // Throw Exception
       throw new OCPPError({
         source: this.getChargingStationID(),
         module: MODULE_NAME,
         method: 'handleRequest',
-        code: OcppErrorType.NOT_IMPLEMENTED,
+        code: OCPPErrorType.NOT_IMPLEMENTED,
         message: `The OCPP method 'handle${typeof commandName === 'string' ? commandName : JSON.stringify(commandName)}' has not been implemented`
       });
     }

--- a/src/server/ocpp/json/WSConnection.ts
+++ b/src/server/ocpp/json/WSConnection.ts
@@ -337,7 +337,7 @@ export default abstract class WSConnection {
         resolve();
       } else {
         // Send timeout
-        setTimeout(() => rejectCallback(`Timeout for Message ID '${messageId}' with content '${messageToSend} (${tenant?.name})`), Constants.OCPP_ERROR_TIMEOUT);
+        setTimeout(() => rejectCallback(`Timeout for Message ID '${messageId}' with content '${messageToSend} (${tenant?.name})`), Constants.OCPP_SOCKET_TIMEOUT);
       }
     });
   }

--- a/src/server/ocpp/json/WSConnection.ts
+++ b/src/server/ocpp/json/WSConnection.ts
@@ -1,4 +1,4 @@
-import { OCPPErrorType, OCPPMessageType } from '../../../types/ocpp/OCPPCommon';
+import { OCPPErrorType, OCPPIncomingRequest, OCPPMessageType, OCPPRequest } from '../../../types/ocpp/OCPPCommon';
 import WebSocket, { CLOSED, CLOSING, CONNECTING, CloseEvent, ErrorEvent, MessageEvent, OPEN } from 'ws';
 
 import BackendError from '../../../exception/BackendError';
@@ -27,10 +27,10 @@ export default abstract class WSConnection {
   protected readonly tenantID: string;
   private readonly token: string;
   private readonly url: string;
-  private readonly clientIP: string|string[];
+  private readonly clientIP: string | string[];
   private readonly wsConnection: WebSocket;
   private req: http.IncomingMessage;
-  private requests: { [id: string]: [(payload?) => void, (reason?: string|OCPPError) => void] };
+  private requests: { [id: string]: OCPPRequest };
   private tenantIsValid: boolean;
 
   constructor(wsConnection: WebSocket, req: http.IncomingMessage, wsServer: JsonCentralSystemServer) {
@@ -112,7 +112,7 @@ export default abstract class WSConnection {
       throw backendError;
     }
     // Handle incoming messages
-    this.wsConnection.on('message',this.onMessage.bind(this));
+    this.wsConnection.on('message', this.onMessage.bind(this));
     // Handle Socket error
     this.wsConnection.on('error', this.onError.bind(this));
     // Handle Socket close
@@ -150,10 +150,10 @@ export default abstract class WSConnection {
   }
 
   public async onMessage(messageEvent: MessageEvent): Promise<void> {
-    let [messageType, messageId, commandName, commandPayload, errorDetails] = [0, '', ServerAction.CHARGING_STATION, '', ''];
+    let [messageType, messageId, commandName, commandPayload, errorDetails]: OCPPIncomingRequest = [0, '', '' as ServerAction, '', ''];
     try {
       // Parse the message
-      [messageType, messageId, commandName, commandPayload, errorDetails] = JSON.parse(messageEvent.toString());
+      [messageType, messageId, commandName, commandPayload, errorDetails] = JSON.parse(messageEvent.toString()) as OCPPIncomingRequest;
       // Initialize: done in the message as init could be lengthy and first message may be lost
       await this.initialize();
       // Check the Type of message
@@ -167,7 +167,7 @@ export default abstract class WSConnection {
         case OCPPMessageType.CALL_RESULT_MESSAGE:
           // Respond
           // eslint-disable-next-line no-case-declarations
-          let responseCallback: Function;
+          let responseCallback: (payload?) => void;
           if (Utils.isIterable(this.requests[messageId])) {
             [responseCallback] = this.requests[messageId];
           } else {
@@ -214,7 +214,7 @@ export default abstract class WSConnection {
             });
           }
           // eslint-disable-next-line no-case-declarations
-          let rejectCallback: Function;
+          let rejectCallback: (reason?: string | OCPPError) => void;
           if (Utils.isIterable(this.requests[messageId])) {
             [, rejectCallback] = this.requests[messageId];
           } else {
@@ -267,11 +267,11 @@ export default abstract class WSConnection {
     return this.url;
   }
 
-  public getClientIP(): string|string[] {
+  public getClientIP(): string | string[] {
     return this.clientIP;
   }
 
-  public async sendError(messageId: string, err: Error|OCPPError): Promise<unknown> {
+  public async sendError(messageId: string, err: Error | OCPPError): Promise<unknown> {
     // Check exception type: only OCPP error are accepted
     const error = (err instanceof OCPPError ? err : new OCPPError({
       source: this.getChargingStationID(),
@@ -285,21 +285,21 @@ export default abstract class WSConnection {
     return this.sendMessage(messageId, error, OCPPMessageType.CALL_ERROR_MESSAGE);
   }
 
-  public async sendMessage(messageId: string, commandParams: any, messageType: OCPPMessageType = OCPPMessageType.CALL_RESULT_MESSAGE, commandName?: Command|ServerAction): Promise<unknown> {
+  public async sendMessage(messageId: string, commandParams: any, messageType: OCPPMessageType = OCPPMessageType.CALL_RESULT_MESSAGE, commandName?: Command | ServerAction): Promise<unknown> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     // Send a message through WSConnection
     const tenant = await TenantStorage.getTenant(this.tenantID);
     // Create a promise
     return await new Promise((resolve, reject) => {
-      let messageToSend;
+      let messageToSend: string;
       // Function that will receive the request's response
       function responseCallback(payload): void {
         // Send the response
         resolve(payload);
       }
       // Function that will receive the request's rejection
-      function rejectCallback(reason: string|OCPPError): void {
+      function rejectCallback(reason: string | OCPPError): void {
         // Build Exception
         self.requests[messageId] = [() => { }, () => { }];
         const error = reason instanceof OCPPError ? reason : new Error(reason);

--- a/src/server/ocpp/json/WSConnection.ts
+++ b/src/server/ocpp/json/WSConnection.ts
@@ -151,6 +151,8 @@ export default abstract class WSConnection {
 
   public async onMessage(messageEvent: MessageEvent): Promise<void> {
     let [messageType, messageId, commandName, commandPayload, errorDetails]: OCPPIncomingRequest = [0, '', '' as ServerAction, '', ''];
+    let responseCallback: (payload?) => void;
+    let rejectCallback: (reason?: string | OCPPError) => void;
     try {
       // Parse the message
       [messageType, messageId, commandName, commandPayload, errorDetails] = JSON.parse(messageEvent.toString()) as OCPPIncomingRequest;
@@ -166,8 +168,6 @@ export default abstract class WSConnection {
         // Outcome Message
         case OCPPMessageType.CALL_RESULT_MESSAGE:
           // Respond
-          // eslint-disable-next-line no-case-declarations
-          let responseCallback: (payload?) => void;
           if (Utils.isIterable(this.requests[messageId])) {
             [responseCallback] = this.requests[messageId];
           } else {
@@ -213,8 +213,6 @@ export default abstract class WSConnection {
               action: commandName
             });
           }
-          // eslint-disable-next-line no-case-declarations
-          let rejectCallback: (reason?: string | OCPPError) => void;
           if (Utils.isIterable(this.requests[messageId])) {
             [, rejectCallback] = this.requests[messageId];
           } else {

--- a/src/server/ocpp/json/WSServer.ts
+++ b/src/server/ocpp/json/WSServer.ts
@@ -62,7 +62,7 @@ export default class WSServer extends WebSocket.Server {
 
   public broadcastToClients(message: any): void {
     for (const client of this.clients) {
-      if (client.readyState === WebSocket.OPEN) {
+      if (client?.readyState === WebSocket.OPEN) {
         client.send(message);
       }
     }

--- a/src/server/rest/v1/service/BillingService.ts
+++ b/src/server/rest/v1/service/BillingService.ts
@@ -533,17 +533,17 @@ export default class BillingService {
       const filename = 'invoice_' + invoice.id + '.' + invoiceDocument.type;
       fs.writeFile(filename, base64RawData, { encoding: invoiceDocument.encoding }, (err) => {
         if (err) {
-          console.log(err);
+          console.error(err);
           throw err;
         }
         res.download(filename, (err2) => {
           if (err2) {
-            console.log(err2);
+            console.error(err2);
             throw err2;
           }
           fs.unlink(filename, (err3) => {
             if (err3) {
-              console.log(err3);
+              console.error(err3);
               throw err3;
             }
           });

--- a/src/types/WebSocket.ts
+++ b/src/types/WebSocket.ts
@@ -1,33 +1,42 @@
 import WSClientConfiguration from './configuration/WSClientConfiguration';
 import WebSocket from 'ws';
 
-export enum MessageType {
-  CALL_MESSAGE = 2, // Caller to Callee
-  CALL_RESULT_MESSAGE = 3, // Callee to Caller
-  CALL_ERROR_MESSAGE = 4, // Callee to Caller
-}
+export const WebSocketCloseEventStatusString: Record<number, string> = Object.freeze({
+  1000: 'Normal Closure',
+  1001: 'Going Away',
+  1002: 'Protocol Error',
+  1003: 'Unsupported Frame Data',
+  1004: 'Reserved',
+  1005: 'No Status Received',
+  1006: 'Abnormal Closure',
+  1007: 'Invalid Frame Payload Data',
+  1008: 'Policy Violation',
+  1009: 'Message Too Large',
+  1010: 'Missing Extension',
+  1011: 'Server Internal Error',
+  1012: 'Service Restart',
+  1013: 'Try Again Later',
+  1014: 'Bad Gateway',
+  1015: 'TLS Handshake'
+});
 
-export enum OcppErrorType {
-  // Requested Action is not known by receiver
-  NOT_IMPLEMENTED = 'NotImplemented',
-  // Requested Action is recognized but not supported by the receiver
-  NOT_SUPPORTED = 'NotSupported',
-  // An internal error occurred and the receiver was not able to process the requested Action successfully
-  INTERNAL_ERROR = 'InternalError',
-  // Payload for Action is incomplete
-  PROTOCOL_ERROR = 'ProtocolError',
-  // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully
-  SECURITY_ERROR = 'SecurityError',
-  // Payload for Action is syntactically incorrect or not conform the PDU structure for Action
-  FORMATION_VIOLATION = 'FormationViolation',
-  // Payload is syntactically correct but at least one field contains an invalid value
-  PROPERTY_RAINT_VIOLATION = 'PropertyraintViolation',
-  // Payload for Action is syntactically correct but at least one of the fields violates occurrence raints
-  OCCURENCE_RAINT_VIOLATION = 'OccurenceraintViolation',
-  // Payload for Action is syntactically correct but at least one of the fields violates data type raints (e.g. "somestring" = 12)
-  TYPERAINT_VIOLATION = 'TyperaintViolation',
-  // Any other error not covered by the previous ones
-  GENERIC_ERROR = 'GenericError',
+export enum WebSocketCloseEventStatusCode {
+  CLOSE_NORMAL = 1000,
+  CLOSE_GOING_AWAY = 1001,
+  CLOSE_PROTOCOL_ERROR = 1002,
+  CLOSE_UNSUPPORTED = 1003,
+  CLOSE_RESERVED = 1004,
+  CLOSE_NO_STATUS = 1005,
+  CLOSE_ABNORMAL = 1006,
+  CLOSE_INVALID_PAYLOAD = 1007,
+  CLOSE_POLICY_VIOLATION = 1008,
+  CLOSE_TOO_LARGE = 1009,
+  CLOSE_MISSING_EXTENSION = 1010,
+  CLOSE_SERVER_INTERNAL_ERROR = 1011,
+  CLOSE_SERVICE_RESTART = 1012,
+  CLOSE_TRY_AGAIN_LATER = 1013,
+  CLOSE_BAD_GATEWAY = 1014,
+  CLOSE_TLS_HANDSHAKE = 1015
 }
 
 export interface WSClientOptions extends WSClientConfiguration {

--- a/src/types/ocpp/OCPPClient.ts
+++ b/src/types/ocpp/OCPPClient.ts
@@ -160,8 +160,8 @@ export enum OCPPChargingProfilePurposeType {
 }
 
 export interface OCPPChangeAvailabilityCommandParam extends OCPPCommandParam {
-  connectorId?: number;
-  type?: OCPPAvailabilityType;
+  connectorId: number;
+  type: OCPPAvailabilityType;
 }
 
 export interface OCPPChangeAvailabilityCommandResult {

--- a/src/types/ocpp/OCPPCommon.ts
+++ b/src/types/ocpp/OCPPCommon.ts
@@ -1,0 +1,28 @@
+export enum OCPPMessageType {
+  CALL_MESSAGE = 2, // Caller to Callee
+  CALL_RESULT_MESSAGE = 3, // Callee to Caller
+  CALL_ERROR_MESSAGE = 4, // Callee to Caller
+}
+
+export enum OCPPErrorType {
+  // Requested Action is not known by receiver
+  NOT_IMPLEMENTED = 'NotImplemented',
+  // Requested Action is recognized but not supported by the receiver
+  NOT_SUPPORTED = 'NotSupported',
+  // An internal error occurred and the receiver was not able to process the requested Action successfully
+  INTERNAL_ERROR = 'InternalError',
+  // Payload for Action is incomplete
+  PROTOCOL_ERROR = 'ProtocolError',
+  // During the processing of Action a security issue occurred preventing receiver from completing the Action successfully
+  SECURITY_ERROR = 'SecurityError',
+  // Payload for Action is syntactically incorrect or not conform the PDU structure for Action
+  FORMATION_VIOLATION = 'FormationViolation',
+  // Payload is syntactically correct but at least one field contains an invalid value
+  PROPERTY_RAINT_VIOLATION = 'PropertyraintViolation',
+  // Payload for Action is syntactically correct but at least one of the fields violates occurrence raints
+  OCCURRENCE_RAINT_VIOLATION = 'OccurrenceraintViolation',
+  // Payload for Action is syntactically correct but at least one of the fields violates data type raints (e.g. "somestring" = 12)
+  TYPERAINT_VIOLATION = 'TyperaintViolation',
+  // Any other error not covered by the previous ones
+  GENERIC_ERROR = 'GenericError',
+}

--- a/src/types/ocpp/OCPPCommon.ts
+++ b/src/types/ocpp/OCPPCommon.ts
@@ -1,3 +1,10 @@
+import OCPPError from '../../exception/OcppError';
+import { ServerAction } from '../Server';
+
+export type OCPPRequest = [(payload?) => void, (reason?: string | OCPPError) => void];
+
+export type OCPPIncomingRequest = [OCPPMessageType, string, ServerAction, string, string];
+
 export enum OCPPMessageType {
   CALL_MESSAGE = 2, // Caller to Callee
   CALL_RESULT_MESSAGE = 3, // Callee to Caller

--- a/src/types/ocpp/OCPPHeader.ts
+++ b/src/types/ocpp/OCPPHeader.ts
@@ -4,11 +4,11 @@ export interface OCPPHeader {
   ocppVersion?: OCPPVersion;
   ocppProtocol?: OCPPProtocol;
   chargeBoxIdentity: string;
-  currentIPAddress?: string|string[];
+  currentIPAddress?: string | string[];
   tenantID: string;
   token?: string;
   chargingStationURL?: string;
   From?: {
-    Address: string|string[];
+    Address: string | string[];
   };
 }

--- a/src/types/ocpp/OCPPServer.ts
+++ b/src/types/ocpp/OCPPServer.ts
@@ -284,7 +284,7 @@ export enum OCPPAuthorizationStatus {
   BLOCKED = 'Blocked',
   EXPIRED = 'Expired',
   INVALID = 'Invalid',
-  CONCURENT_TX = 'ConcurrentTx'
+  CONCURRENT_TX = 'ConcurrentTx'
 }
 
 export interface OCPPDiagnosticsStatusNotificationRequest {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -84,7 +84,7 @@ export default class Constants {
   public static readonly WS_DEFAULT_RECONNECT_MAX_RETRIES = -1;
   public static readonly WS_DEFAULT_RECONNECT_TIMEOUT = 30; // Seconds
 
-  public static readonly OCPP_ERROR_TIMEOUT = 30000; // 30 sec
+  public static readonly OCPP_SOCKET_TIMEOUT = 30000; // 30 sec
 
   public static readonly MAX_DATE = new Date('9999-12-31Z23:59:59:999');
   public static readonly MIN_DATE = new Date('1970-01-01Z00:00:00:000');

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -83,10 +83,8 @@ export default class Constants {
   public static readonly WS_RECONNECT_UNLIMITED = -1;
   public static readonly WS_DEFAULT_RECONNECT_MAX_RETRIES = -1;
   public static readonly WS_DEFAULT_RECONNECT_TIMEOUT = 30; // Seconds
-  public static readonly WS_UNSUPPORTED_DATA = 1007;
 
-  public static readonly OCPP_SOCKET_TIMEOUT = 30000; // 30 sec
-  public static readonly OCPP_RESPONSE_ACCEPTED = 'Accepted';
+  public static readonly OCPP_ERROR_TIMEOUT = 30000; // 30 sec
 
   public static readonly MAX_DATE = new Date('9999-12-31Z23:59:59:999');
   public static readonly MIN_DATE = new Date('1970-01-01Z00:00:00:000');

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -20,6 +20,7 @@ import Tag from '../types/Tag';
 import Tenant from '../types/Tenant';
 import TenantComponents from '../types/TenantComponents';
 import UserToken from '../types/UserToken';
+import { WebSocketCloseEventStatusString } from '../types/WebSocket';
 import _ from 'lodash';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
@@ -334,6 +335,26 @@ export default class Utils {
       case ConnectorCurrentLimitSource.STATIC_LIMITATION:
         return 'Static Limitation';
     }
+  }
+
+  public static getWebSocketCloseEventStatusString(code: number): string {
+    if (code >= 0 && code <= 999) {
+      return '(Unused)';
+    } else if (code >= 1016) {
+      if (code <= 1999) {
+        return '(For WebSocket standard)';
+      } else if (code <= 2999) {
+        return '(For WebSocket extensions)';
+      } else if (code <= 3999) {
+        return '(For libraries and frameworks)';
+      } else if (code <= 4999) {
+        return '(For applications)';
+      }
+    }
+    if (!Utils.isUndefined(WebSocketCloseEventStatusString[code])) {
+      return WebSocketCloseEventStatusString[code];
+    }
+    return '(Unknown)';
   }
 
   public static convertToBoolean(value: any): boolean {

--- a/test/api/client/utils/BaseApi.ts
+++ b/test/api/client/utils/BaseApi.ts
@@ -29,15 +29,15 @@ export default class BaseApi {
       httpResponse = await axiosInstance(httpRequest);
       // Debug
       if (config.trace_logs) {
-        console.log('HTTP Request ====================================');
-        console.log(httpRequest.baseURL);
-        console.log(httpRequest.url);
-        console.log(httpRequest.method);
-        console.log(httpRequest.data);
-        console.log(httpResponse.status);
-        console.log(httpResponse.statusText);
-        console.log(httpResponse.data);
-        console.log('====================================');
+        console.debug('HTTP Request ====================================');
+        console.debug(httpRequest.baseURL);
+        console.debug(httpRequest.url);
+        console.debug(httpRequest.method);
+        console.debug(httpRequest.data);
+        console.debug(httpResponse.status);
+        console.debug(httpResponse.statusText);
+        console.debug(httpResponse.data);
+        console.debug('====================================');
       }
       t1 = performance.now();
     } catch (error) {

--- a/test/api/ocpp/json/OCPPJsonService16.ts
+++ b/test/api/ocpp/json/OCPPJsonService16.ts
@@ -1,9 +1,10 @@
-import { MessageType, WSClientOptions } from '../../../../src/types/WebSocket';
 import { OCPP15MeterValuesRequest, OCPPAuthorizeRequest, OCPPAuthorizeResponse, OCPPBootNotificationRequest, OCPPBootNotificationResponse, OCPPDataTransferRequest, OCPPDataTransferResponse, OCPPDiagnosticsStatusNotificationRequest, OCPPDiagnosticsStatusNotificationResponse, OCPPFirmwareStatusNotificationRequest, OCPPFirmwareStatusNotificationResponse, OCPPHeartbeatRequest, OCPPHeartbeatResponse, OCPPMeterValuesRequest, OCPPMeterValuesResponse, OCPPStartTransactionRequest, OCPPStartTransactionResponse, OCPPStatusNotificationRequest, OCPPStatusNotificationResponse, OCPPStopTransactionRequest, OCPPStopTransactionResponse, OCPPVersion } from '../../../../src/types/ocpp/OCPPServer';
 
+import { OCPPMessageType } from '../../../../src/types/ocpp/OCPPCommon';
 import OCPPService from '../OCPPService';
 import Utils from '../../../../src/utils/Utils';
 import WSClient from '../../../../src/client/websocket/WSClient';
+import { WSClientOptions } from '../../../../src/types/WebSocket';
 import config from '../../../config';
 import { performance } from 'perf_hooks';
 
@@ -59,7 +60,7 @@ export default class OCPPJsonService16 extends OCPPService {
           // Parse the message
           const messageJson = JSON.parse(message.data);
           // Check if this corresponds to a request
-          if (messageJson[0] === MessageType.CALL_RESULT_MESSAGE && sentRequests[messageJson[1]]) {
+          if (messageJson[0] === OCPPMessageType.CALL_RESULT_MESSAGE && sentRequests[messageJson[1]]) {
             const response: any = {};
             // Set the data
             response.responseMessageId = messageJson[1];
@@ -67,7 +68,7 @@ export default class OCPPJsonService16 extends OCPPService {
             response.data = messageJson[2];
             // Respond to the request
             sentRequests[messageJson[1]].resolve(response);
-          } else if (messageJson[0] === MessageType.CALL_MESSAGE) {
+          } else if (messageJson[0] === OCPPMessageType.CALL_MESSAGE) {
             const [messageType, messageId, commandName, commandPayload] = messageJson;
             await this.handleRequest(chargeBoxIdentity, messageId, commandName, commandPayload);
           }
@@ -147,9 +148,9 @@ export default class OCPPJsonService16 extends OCPPService {
   private async send(chargeBoxIdentity: string, message: any): Promise<any> {
     // Debug
     if (config.trace_logs) {
-      console.log('OCPP Request ====================================');
-      console.log({ chargeBoxIdentity, message });
-      console.log('====================================');
+      console.debug('OCPP Request ====================================');
+      console.debug({ chargeBoxIdentity, message });
+      console.debug('====================================');
     }
     // WS Opened?
     if (!this.wsSessions?.get(chargeBoxIdentity)?.connection?.isConnectionOpen()) {
@@ -160,9 +161,9 @@ export default class OCPPJsonService16 extends OCPPService {
     // Send
     const t0 = performance.now();
     this.wsSessions.get(chargeBoxIdentity).connection.send(JSON.stringify(message), {}, (error?: Error) => {
-      config.trace_logs && console.log(`Sending error to '${chargeBoxIdentity}', error '${JSON.stringify(error)}', message: '${JSON.stringify(message)}'`);
+      config.trace_logs && console.debug(`Sending error to '${chargeBoxIdentity}', error '${JSON.stringify(error)}', message: '${JSON.stringify(message)}'`);
     });
-    if (message[0] === MessageType.CALL_MESSAGE) {
+    if (message[0] === OCPPMessageType.CALL_MESSAGE) {
       // Return a promise
       // eslint-disable-next-line no-undef
       return new Promise((resolve, reject) => {
@@ -175,7 +176,7 @@ export default class OCPPJsonService16 extends OCPPService {
   private buildRequest(command: string, payload: any) {
     // Build the request
     return [
-      MessageType.CALL_MESSAGE,
+      OCPPMessageType.CALL_MESSAGE,
       Utils.generateUUID(),
       command,
       payload];
@@ -184,7 +185,7 @@ export default class OCPPJsonService16 extends OCPPService {
   private buildResponse(messageId, payload: any) {
     // Build the request
     return [
-      MessageType.CALL_MESSAGE,
+      OCPPMessageType.CALL_MESSAGE,
       messageId,
       payload];
   }


### PR DESCRIPTION
Update: 

+ Reverted unwanted changes; 
+ Make DB logging unconditional (no tunable for simplicity) where possible (not in WSClient class);  
+ Make console logging conditional to the env type, like all other console logs. 

Update 2: 

+ Remove useless console logging (in WSClient it has to stay).	

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>