### PR TITLE
Charging station vendors string might be longer than 20 characters

### DIFF
--- a/src/assets/server/ocpp/schemas/boot-notification-request.json
+++ b/src/assets/server/ocpp/schemas/boot-notification-request.json
@@ -7,7 +7,7 @@
             "type": "string",
             "description": "string defining the vendor of the charge point. To be treated as case insensitive.",
             "minLength": 1,
-            "maxLength": 20
+            "maxLength": 25
         },
         "chargePointModel": {
             "type": "string",


### PR DESCRIPTION
And thus violate the OCPP specs.

Required by SAP Italy.

Signed-off-by: Jérôme Benoit <jerome.benoit@sap.com>